### PR TITLE
It's grammared significantly

### DIFF
--- a/2017-12/index.html
+++ b/2017-12/index.html
@@ -15,7 +15,7 @@
         <h2>Results</h2>
         <p>Microsoft Edge lasted 79% longer than Firefox, 29% longer than Chrome, and 40% longer than Opera in this test.</p>
         <p>Additional numbers were generated to control for battery health and to reflect what the performance might have looked like if the battery run-down had consumed the battery design capacity of the device. This was used as a gut-check to ensure that
-            one browser wouldn't significant outperform another in conditions where battery health had deteriorated.</p><img src="rundown-results.png" width="744" height="414" />
+            one browser wouldn't significantly outperform another in conditions where battery health had deteriorated.</p><img src="rundown-results.png" width="744" height="414" />
         <table class="resultsTable">
             <tr>
                 <td>Browser / Version</td>


### PR DESCRIPTION
"Additional numbers were generated to control for battery health and to reflect what the performance might have looked like if the battery run-down had consumed the battery design capacity of the device. This was used as a gut-check to ensure that one browser wouldn't *significant* outperform another in conditions where battery health had deteriorated."